### PR TITLE
a10/asvr/db: remove deprecated cursor.count() call

### DIFF
--- a/a10/a10/asvr/db/core.py
+++ b/a10/a10/asvr/db/core.py
@@ -41,7 +41,7 @@ def getDatabaseStatus():
         "log",
     ]:
         collection = asdb[c]
-        count = collection.find().count()
+        count = collection.estimated_document_count()
         dbstatus[c] = str(count)
 
     return dbstatus


### PR DESCRIPTION
This is not supported in pymongo 4:
https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#collection-count-and-cursor-count-is-removed

Without this the u10 Docker container just crashes.