### PR TITLE
a10/asvr/db: remove another deprecated cursor.count() call

### DIFF
--- a/a10/a10/asvr/db/core.py
+++ b/a10/a10/asvr/db/core.py
@@ -90,7 +90,7 @@ def getLogEntryCount():
 	:rtype: int
 	"""
     collection = asdb["log"]
-    return collection.find().count()
+    return collection.estimated_document_count()
 
 
 ##################################################


### PR DESCRIPTION
I found another deprecated call.